### PR TITLE
compatibility with Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-nodeunit": "^0.4.1",
-    "grunt": "~0.4.1"
+    "grunt": ">=0.4.0"
   },
   "peerDependencies": {
     "grunt": ">=0.4.1"


### PR DESCRIPTION
An error occurs when trying to install grunt-filerev-assets with Grunt 1.0:

```sh
npm ERR! peerinvalid Peer grunt-filerev-assets@0.3.2 wants grunt@~0.4.1
```

This PR adds compatibility with Grunt 1.0.
Fixes: https://github.com/richardbolt/grunt-filerev-assets/issues/10
